### PR TITLE
AppEntry: remove app_notifications

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -179,7 +179,7 @@ public class Notifications.Indicator : Wingpanel.Indicator {
             var entry = (NotificationEntry) nlist.notification_items.get_item (i);
             if (id == entry.notification.server_id) {
                 entry.notification.server_id = 0; // Notification is now outdated
-                entry.clear ();
+                entry.dismiss ();
                 return;
             }
         }

--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -114,9 +114,5 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
 
     private void remove_notification_entry (NotificationEntry entry) {
         app_notifications.remove (entry);
-
-        if (app_notifications.length () == 0) {
-            clear ();
-        }
     }
 }

--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -112,9 +112,8 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
         entry.clear.connect (remove_notification_entry);
     }
 
-    public void remove_notification_entry (NotificationEntry entry) {
+    private void remove_notification_entry (NotificationEntry entry) {
         app_notifications.remove (entry);
-        entry.dismiss ();
 
         if (app_notifications.length () == 0) {
             if (headers.remove (app_id)) {

--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -8,7 +8,6 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
 
     public string app_id { get; private set; }
     public AppInfo? app_info { get; construct; default = null; }
-    public List<NotificationEntry> app_notifications;
 
     private static Gtk.CssProvider provider;
     private static Settings settings;
@@ -34,8 +33,6 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
     }
 
     construct {
-        app_notifications = new List<NotificationEntry> ();
-
         unowned string name;
         if (app_info != null) {
             app_id = app_info.get_id ();
@@ -105,14 +102,5 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
             targetval = (bool) srcval ? _("Show less") : _("Show more");
             return true;
         });
-    }
-
-    public void add_notification_entry (NotificationEntry entry) {
-        app_notifications.prepend (entry);
-        entry.clear.connect (remove_notification_entry);
-    }
-
-    private void remove_notification_entry (NotificationEntry entry) {
-        app_notifications.remove (entry);
     }
 }

--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -116,10 +116,6 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
         app_notifications.remove (entry);
 
         if (app_notifications.length () == 0) {
-            if (headers.remove (app_id)) {
-                settings.set_value ("headers", headers);
-            }
-
             clear ();
         }
     }

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -4,7 +4,6 @@
 */
 
 public class Notifications.NotificationEntry : Gtk.ListBoxRow {
-    public signal void clear ();
     public signal void remove ();
 
     public Notification notification { get; construct; }
@@ -223,7 +222,6 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         child = revealer;
 
         delete_button.clicked.connect (() => {
-            clear ();
             dismiss ();
         });
 
@@ -252,7 +250,6 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
         carousel.page_changed.connect (() => {
             if (carousel.position != 1) {
-                clear ();
                 dismiss ();
             }
         });

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -222,7 +222,10 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
         child = revealer;
 
-        delete_button.clicked.connect (() => clear ());
+        delete_button.clicked.connect (() => {
+            clear ();
+            dismiss ();
+        });
 
         var motion_controller = new Gtk.EventControllerMotion ();
 
@@ -250,6 +253,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         carousel.page_changed.connect (() => {
             if (carousel.position != 1) {
                 clear ();
+                dismiss ();
             }
         });
     }

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -190,7 +190,7 @@ public class Notifications.NotificationsList : Granite.Bin {
                 try {
                     var context = notification_entry.get_display ().get_app_launch_context ();
                     notification_entry.notification.app_info.launch (null, context);
-                    notification_entry.clear ();
+                    notification_entry.dismiss ();
                     close_popover ();
                 } catch (Error e) {
                     warning ("Unable to launch app: %s", e.message);

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -169,6 +169,8 @@ public class Notifications.NotificationsList : Granite.Bin {
         );
 
         if (items_for_appid.n_items == 0) {
+            clear_app_entry (app_entries[app_id]);
+
             var settings = new Settings ("io.elementary.panel.notifications");
             var headers = (HashTable<string, bool>) settings.get_value ("headers");
             if (headers.remove (app_id)) {

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -137,12 +137,6 @@ public class Notifications.NotificationsList : Granite.Bin {
         app_entries.unset (app_entry.app_id);
         app_entry.app_notifications = new List<NotificationEntry> ();
 
-        var settings = new Settings ("io.elementary.panel.notifications");
-        var headers = (HashTable<string, bool>) settings.get_value ("headers");
-        if (headers.remove (app_entry.app_id)) {
-            settings.set_value ("headers", headers);
-        }
-
         Notification[] to_remove = {};
         for (int i = 0; i < list_store.n_items; i++) {
             var entry = (NotificationEntry) list_store.get_item (i);
@@ -160,10 +154,26 @@ public class Notifications.NotificationsList : Granite.Bin {
     }
 
     private void remove_notification (NotificationEntry notification_entry) {
+        var app_id = notification_entry.notification.desktop_id;
+
         uint pos = -1;
         if (list_store.find (notification_entry, out pos)) {
             list_store.remove (pos);
             Session.get_instance ().remove_notification (notification_entry.notification);
+        }
+
+        var items_for_appid = new Gtk.FilterListModel (
+            list_store, new Gtk.CustomFilter ((item) => {
+                return ((NotificationEntry) item).notification.desktop_id == app_id;
+            })
+        );
+
+        if (items_for_appid.n_items == 0) {
+            var settings = new Settings ("io.elementary.panel.notifications");
+            var headers = (HashTable<string, bool>) settings.get_value ("headers");
+            if (headers.remove (app_id)) {
+                settings.set_value ("headers", headers);
+            }
         }
     }
 

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -100,8 +100,6 @@ public class Notifications.NotificationsList : Granite.Bin {
             app_entries[row_app_id] = app_entry;
         }
 
-        app_entry.add_notification_entry (row_entry);
-
         row.set_header (app_entries[row_app_id]);
     }
 
@@ -135,7 +133,6 @@ public class Notifications.NotificationsList : Granite.Bin {
     private void clear_app_entry (AppEntry app_entry) {
         app_entry.clear.disconnect (clear_app_entry);
         app_entries.unset (app_entry.app_id);
-        app_entry.app_notifications = new List<NotificationEntry> ();
 
         Notification[] to_remove = {};
         for (int i = 0; i < list_store.n_items; i++) {


### PR DESCRIPTION
Remove a round trip where `NotificationEntry.clear ()` → `AppEntry.remove_notification_entry ()` → `NotificationEntry.dismiss ()` can just be NotificationEntry calling dismiss internally

Moving counting and unsetting headers from `NotificationEntry.clear ()` → `AppEntry.remove_notification_entry ()`  to `NotificationEntry.remove ()` → `NotificationsList.remove_notification ()`
*  This uses a FilterListModel to count the items for a given `app_id` from the `ListStore` which is our source of truth
* We also get to remove unsetting headers from `clear_app_entry` because we already call `NotificationEntry.dismiss ()` → `NotificationEntry.remove ()` → `NotificationsList.remove_notification ()`

Now that we count up `items_for_appid` when removing, call `clear_app_entry ()` here using the handy `HashMap` of `app_id`s.

Remove the list of notifications from AppEntry.

Finally, remove the unused `clear ()` signal and make sure external calls are to the function `dimiss ()` instead

Rebase merge if desired