### PR TITLE
NotificationEntry: connect to server_id

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -179,7 +179,6 @@ public class Notifications.Indicator : Wingpanel.Indicator {
             var entry = (NotificationEntry) nlist.notification_items.get_item (i);
             if (id == entry.notification.server_id) {
                 entry.notification.server_id = 0; // Notification is now outdated
-                entry.clear ();
                 return;
             }
         }

--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -114,7 +114,7 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
 
     public void remove_notification_entry (NotificationEntry entry) {
         app_notifications.remove (entry);
-        entry.dismiss ();
+        entry.notification.server_id = 0;
 
         if (app_notifications.length () == 0) {
             if (headers.remove (app_id)) {

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -252,6 +252,12 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
                 clear ();
             }
         });
+
+        notification.notify["server-id"].connect (() => {
+            if (notification.server_id == 0) {
+                dismiss ();
+            }
+        });
     }
 
     private static bool get_bind_func (Value value, Variant variant, void* user_data) {
@@ -261,7 +267,7 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
         return true;
     }
 
-    public void dismiss () {
+    private void dismiss () {
         Source.remove (timeout_id);
 
         if (!revealer.child_revealed) {

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -147,7 +147,7 @@ public class Notifications.NotificationsList : Granite.Bin {
         for (int i = 0; i < list_store.n_items; i++) {
             var entry = (NotificationEntry) list_store.get_item (i);
             if (entry.notification.desktop_id == app_entry.app_id) {
-                entry.dismiss ();
+                entry.notification.server_id = 0;
                 to_remove += entry.notification;
             }
         }
@@ -181,7 +181,7 @@ public class Notifications.NotificationsList : Granite.Bin {
                 try {
                     var context = notification_entry.get_display ().get_app_launch_context ();
                     notification_entry.notification.app_info.launch (null, context);
-                    notification_entry.clear ();
+                    notification_entry.notification.server_id = 0;
                     close_popover ();
                 } catch (Error e) {
                     warning ("Unable to launch app: %s", e.message);


### PR DESCRIPTION
Instead of directly dismissing the notification row widget, we should mark these notifications as outdated and then let the row listen to that property. This is going to come in handy to make our `NotificationsList` `ListStore` be a list of `Notifications` and not `NotificationEntry`s, a pre-req for performant `ListViews`