### PR TITLE
AppEntry: don't hold appinfo

### DIFF
--- a/src/Services/Notification.vala
+++ b/src/Services/Notification.vala
@@ -143,9 +143,12 @@ public class Notifications.Notification : Object {
             }
         }
 
-        if (app_info == null) {
-            desktop_id = FALLBACK_DESKTOP_ID;
+        if (app_info != null) {
+            app_name = app_info.get_display_name ();
+        } else {
             app_info = new DesktopAppInfo (desktop_id);
+            app_name = _("Other");
+            desktop_id = FALLBACK_DESKTOP_ID;
         }
     }
 

--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -6,8 +6,8 @@
 public class Notifications.AppEntry : Gtk.ListBoxRow {
     public signal void clear ();
 
-    public string app_id { get; private set; }
-    public AppInfo? app_info { get; construct; default = null; }
+    public string app_id { get; construct; }
+    public string app_name { get; construct; }
 
     private static Gtk.CssProvider provider;
     private static Settings settings;
@@ -28,23 +28,17 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
         headers = (HashTable<string, bool>) settings.get_value ("headers");
     }
 
-    public AppEntry (AppInfo? app_info) {
-        Object (app_info: app_info);
+    public AppEntry (string app_id, string app_name) {
+        Object (
+            app_id: app_id,
+            app_name: app_name
+        );
     }
 
     construct {
-        unowned string name;
-        if (app_info != null) {
-            app_id = app_info.get_id ();
-            name = app_info.get_name ();
-        } else {
-            app_id = "other";
-            name = _("Other");
-        }
-
         var image = new Gtk.Image.from_icon_name ("pan-end-symbolic");
 
-        var label = new Gtk.Label (name) {
+        var label = new Gtk.Label (app_name) {
             hexpand = true,
             xalign = 0
         };

--- a/src/Widgets/NotificationEntry.vala
+++ b/src/Widgets/NotificationEntry.vala
@@ -222,11 +222,6 @@ public class Notifications.NotificationEntry : Gtk.ListBoxRow {
 
         var entry_title = notification.summary;
         if (notification.message_body == "") {
-            //FIXME: This should probably be done in Notification
-            if (notification.app_name == "" && notification.app_info != null) {
-                notification.app_name = notification.app_info.get_display_name ();
-            }
-
             entry_title = notification.app_name;
         }
 

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -94,7 +94,7 @@ public class Notifications.NotificationsList : Granite.Bin {
 
         var app_entry = app_entries[row_app_id];
         if (app_entry == null) {
-            app_entry = new AppEntry (row_entry.notification.app_info);
+            app_entry = new AppEntry (row_app_id, row_entry.notification.app_name);
             app_entry.clear.connect (clear_app_entry);
 
             app_entries[row_app_id] = app_entry;


### PR DESCRIPTION
Instead of AppEntry holding its own AppInfo object (wow expensive), have it get name and ID from the notification.

While we're here, move some fixups to Notification so that the two are always in sync about what the app name is.