### PR TITLE
AppEntry: make properties settable

### DIFF
--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -6,8 +6,21 @@
 public class Notifications.AppEntry : Gtk.ListBoxRow {
     public signal void clear ();
 
-    public string app_id { get; construct; }
-    public string app_name { get; construct; }
+    private string _app_id = "";
+    public string app_id {
+        get {
+            return _app_id;
+        }
+        set {
+            _app_id = value;
+
+            if (value in headers) {
+                expander.active = headers[value];
+            }
+        }
+    }
+
+    public string app_name { get; set; default = ""; }
 
     private static Gtk.CssProvider provider;
     private static Settings settings;
@@ -26,13 +39,6 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
 
         settings = new Settings ("io.elementary.panel.notifications");
         headers = (HashTable<string, bool>) settings.get_value ("headers");
-    }
-
-    public AppEntry (string app_id, string app_name) {
-        Object (
-            app_id: app_id,
-            app_name: app_name
-        );
     }
 
     construct {
@@ -75,9 +81,7 @@ public class Notifications.AppEntry : Gtk.ListBoxRow {
         can_focus = false;
         child = box;
 
-        if (app_id in headers) {
-            expander.active = headers[app_id];
-        }
+        bind_property ("app-name", label, "label");
 
         expander.toggled.connect (() => {
             headers[app_id] = expander.active;

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -94,7 +94,10 @@ public class Notifications.NotificationsList : Granite.Bin {
 
         var app_entry = app_entries[row_app_id];
         if (app_entry == null) {
-            app_entry = new AppEntry (row_app_id, row_entry.notification.app_name);
+            app_entry = new AppEntry () {
+                app_name = row_entry.notification.app_name,
+                app_id = row_app_id
+            };
             app_entry.clear.connect (clear_app_entry);
 
             app_entries[row_app_id] = app_entry;


### PR DESCRIPTION
Headers in ListView also use a signal factory so make these properties settable so we can recycle widgets there too