### PR TITLE
NotificationsList: invalidate section sort when a new apptime is set

### DIFF
--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -111,6 +111,7 @@ public class Notifications.NotificationsList : Granite.Bin {
         unowned GLib.DateTime? time = app_datetime[notification.desktop_id];
         if (time == null || time.compare (notification.timestamp) <= 0) {
             app_datetime[notification.desktop_id] = notification.timestamp;
+            sort_list_model.section_sorter.changed (DIFFERENT);
         }
 
         list_store.append (notification);

--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -19,6 +19,8 @@ public class Notifications.NotificationsList : Granite.Bin {
         }
     }
 
+    private Gtk.SortListModel sort_list_model;
+
     construct {
         app_datetime = new GLib.HashTable<string, GLib.DateTime> (str_hash, str_equal);
 
@@ -34,7 +36,7 @@ public class Notifications.NotificationsList : Granite.Bin {
 
         list_store = new GLib.ListStore (typeof (Notification));
 
-        var sort_list_model = new Gtk.SortListModel (list_store, new Gtk.CustomSorter ((GLib.CompareDataFunc<GLib.Object>) Notification.compare)) {
+        sort_list_model = new Gtk.SortListModel (list_store, new Gtk.CustomSorter ((GLib.CompareDataFunc<GLib.Object>) Notification.compare)) {
             section_sorter = new Gtk.CustomSorter ((GLib.CompareDataFunc<GLib.Object>) section_func)
         };
 


### PR DESCRIPTION
Fixes duplicate headers. Make sure we invalidate the section sorter when we add a new app time