### PR TITLE
NotificationsList: don't assume null time

### DIFF
--- a/src/Widgets/NotificationsList.vala
+++ b/src/Widgets/NotificationsList.vala
@@ -35,7 +35,7 @@ public class Notifications.NotificationsList : Granite.Bin {
         list_store = new GLib.ListStore (typeof (Notification));
 
         var sort_list_model = new Gtk.SortListModel (list_store, new Gtk.CustomSorter ((GLib.CompareDataFunc<GLib.Object>) Notification.compare)) {
-            section_sorter = new Gtk.CustomSorter ((GLib.CompareDataFunc<GLib.Object>) section_func)
+            section_sorter = new Gtk.CustomSorter ((GLib.CompareDataFunc<GLib.Object>) section_compare)
         };
 
         var listbox = new Gtk.ListBox () {
@@ -63,19 +63,8 @@ public class Notifications.NotificationsList : Granite.Bin {
         });
     }
 
-    private static int section_func (Notification a, Notification b) {
-        unowned GLib.DateTime? time_a = app_datetime[a.desktop_id];
-        unowned GLib.DateTime? time_b = app_datetime[b.desktop_id];
-
-        if (time_a != null && time_b != null) {
-            return time_b.compare (time_a);
-        } else if (time_a != null) {
-            return -1;
-        } else if (time_b != null) {
-            return 1;
-        }
-
-        return 0;
+    private static int section_compare (Notification a, Notification b) {
+        return app_datetime[b.desktop_id].compare (app_datetime[a.desktop_id]);
     }
 
     private void header_func (Gtk.ListBoxRow row, Gtk.ListBoxRow? before) {


### PR DESCRIPTION
We always assign a timestamp and we always add timestamps to `app_datetime` so there's no reason to assume null is possible here?